### PR TITLE
Enable in:filename syntax

### DIFF
--- a/harvester.js
+++ b/harvester.js
@@ -53,7 +53,7 @@
 	function harvest(realQuery, bogusQuery = null){
 		harvesting = true;
 		
-		if(!/^extension:|filename:/.test(realQuery))
+		if(!/^extension:|filename:|in:filename/.test(realQuery))
 			realQuery = "extension:" + realQuery;
 		
 		return new Promise(resolve => {


### PR DESCRIPTION
Queries starting with `in:filename` are also valid queries and don't require an `extension:` prefix.
Found the issue while trying to retrieve samples for `in:filename uosl.q`. Harvester then returned a `No results` exception :/

I've made the change pretty quickly (but it currently runs!), so tell me if I missed some additional changes that are required.