### PR TITLE
Fix make install command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SRC    = harvester.js
 TARGET = bookmarklet.js
 
 all: install lint $(TARGET)
-	
+
 
 # Compile/minify bookmarklet
 $(TARGET): $(SRC)
@@ -20,8 +20,8 @@ lint:
 
 # Install required dependencies
 install:
-	@(command -v uglifyjs 2>&1 >/dev/null) || npm -g uglify-es
-	@(command -v eslint   2>&1 >/dev/null) || npm -g eslint
+	@(command -v uglifyjs 2>&1 >/dev/null) || npm install -g uglify-es
+	@(command -v eslint   2>&1 >/dev/null) || npm install -g eslint
 
 
 # Delete generated files


### PR DESCRIPTION
I had to change the following to be able to run `make install`. Not sure whether this was working with a previous version of npm or if it's an oversight, so I'm opening this pull request (sorry, I really like pull requests :p) for confirmation.